### PR TITLE
Refactor: Improve HTML Structure and Add Application Entry Point

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Give [Omen](https://github.com/omen-osdev/omen) a try, right inside your browser
 pip install -r requirements.txt
 ```
 
-#### Now run using:
+#### Running in development mode:
 ```bash
-flask --app app run --debug
+cd app
+python app.py
 ```
-
+#### Running in production mode:
+```bash
+TODO
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,7 @@ import os
 
 from flask import Flask, render_template
 
-from app.instance import build_image
 from instance import *
-
 
 def create_app(test_config=None):
     # create and configure the app
@@ -34,4 +32,6 @@ def create_app(test_config=None):
 
     return app
     
-    
+if __name__ == '__main__':
+    app = create_app()
+    app.run()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,19 @@ from flask import Flask, render_template
 from instance import *
 
 def create_app(test_config=None):
-    # create and configure the app
+    """
+    
+    Create and configure an instance of the Flask application.
+
+    :param test_config: dict, optional
+        A dictionary containing the configuration for the application.
+        If provided, this configuration will be used instead of the default
+        values.
+    :return: Flask
+        The created Flask application
+    
+    """
+
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_mapping(
         SECRET_KEY=os.environ.get('SECRET_KEY', 'dev'),
@@ -25,6 +37,8 @@ def create_app(test_config=None):
     except OSError:
         pass
 
+    # use test_config here
+
 
     @app.route('/')
     def home():
@@ -34,4 +48,4 @@ def create_app(test_config=None):
     
 if __name__ == '__main__':
     app = create_app()
-    app.run()
+    app.run(debug=True)

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,3 +1,21 @@
+body {
+  position: fixed;
+  left: 0px;
+  right: 0px;
+  top: 0px;
+  bottom: 0px;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+}
+
+#canvas {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
 .frosted-glass {
   position: absolute;
   top: 50%;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,8 +11,8 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon" />
 </head>
 
-  <body style="position: fixed; left: 0px; right: 0px; top: 0px; bottom: 0px; overflow: hidden; margin: 0; padding: 0;">
-    <canvas id="canvas" style="width: 100%; height: 100%; padding: 0; margin: 0;"></canvas>
+  <body>
+    <canvas id="canvas"></canvas>
 
     <div class="frosted-glass unselectable">
       <p class="text">Omen Live Demo</p>


### PR DESCRIPTION
I've done a few changes that I thought might be contributional

* **HTML Refactoring:**
1) Removed all inline styles from the <body> and <canvas> elements in the index.html file.
2) Improved readability and maintainability by moving styling concerns to external CSS (styles.css).
3) Ensured a cleaner separation of content (HTML) and presentation (CSS), adhering to best practices.

* **Application Entry Point:**
This change enables the application to be run directly as a standalone script.
Like so:
```bash
cd app
python3 __init__.py
```


